### PR TITLE
YOLO v8 with  normalized output tensors

### DIFF
--- a/tensor-groups/yolo-v8-segmentation-out-normalized.md
+++ b/tensor-groups/yolo-v8-segmentation-out-normalized.md
@@ -1,0 +1,80 @@
+# YOLOv8 Segmentation (Normalized)
+
+- tensor-group: yes
+- layer-type: output
+- use-case: instance-segmentation
+
+## Description
+
+Variant of YOLOv8 segmentation model outputs for models exported with older Ultralytics
+versions that do not embed stride multiplication in the ONNX detect head.
+
+This tensor group has the same structure as [yolo-v8-segmentation-out](/tensor-groups/yolo-v8-segmentation-out.md)
+except that bounding box coordinates (X, Y, W, H) in the detections tensor are **normalized to [0, 1]**
+relative to the input image dimensions, rather than expressed in pixel space.
+
+YOLOv8 Segmentation Output Tensors:
+| Name          | Shape                    | Description |
+|---            |---                       |---          |
+| [detections]  | 1 x 116 x NUM_CANDIDATES | Detection results with mask coefficients (normalized bbox) |
+| [protos]      | 1 x 32 x PROTO_H x PROTO_W | Prototype mask patterns |
+
+## Tensor Decoding Logic
+
+```
+# Apply NMS to get valid detections
+valid_detections = non_max_suppression(detections[0], conf_threshold, iou_threshold)
+
+Foreach i in valid_detections:
+    # Extract normalized bounding box coordinates and scale to pixels
+    X = detections[0, 0, i] * image_width
+    Y = detections[0, 1, i] * image_height
+    W = detections[0, 2, i] * image_width
+    H = detections[0, 3, i] * image_height
+
+    # Extract class probabilities and find best class
+    class_scores = detections[0, 4:(4 + NUM_CLASSES), i]
+    C = argmax(class_scores)
+    S = max(class_scores)
+
+    # Extract mask coefficients
+    mask_coeffs = detections[0, (4 + NUM_CLASSES):(4 + NUM_CLASSES + NUM_MASKS), i]  # NUM_MASKS coefficients
+
+    # Generate segmentation mask using prototype masks
+    Foreach pixel (y, x) in mask_region:
+        pixel_index = y * PROTO_W + x
+        mask_value = 0.0
+
+        # Linear combination of prototypes
+        Foreach k in 0:(NUM_MASKS-1):                     # NUM_MASKS prototypes
+            prototype_value = protos[0, k, y, x]
+            mask_value += mask_coeffs[k] * prototype_value
+
+        # Apply sigmoid and threshold
+        final_mask[y, x] = sigmoid(mask_value) > 0.5 ? 1 : 0
+
+    # Scale and crop mask to bounding box
+    segmentation_mask = scale_and_crop(final_mask, X, Y, W, H, image_size)
+
+    # Store result
+    results[i] = [X, Y, W, H, C, S, segmentation_mask]
+```
+
+## External References
+
+* [YOLOv8 Paper](https://arxiv.org/abs/2305.09972)
+* [Ultralytics YOLOv8 Documentation](https://docs.ultralytics.com/models/yolov8/)
+* [Ultralytics ONNX export source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py)
+
+## Models
+
+* [YOLOv8s-seg (old Ultralytics export)](https://github.com/ultralytics/assets/releases)
+
+## Tensor Decoders
+
+|Framework  | Links |
+|---        |---    |
+|GStreamer  | [yolov8tensordec](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/tensordecoders) |
+
+[detections]: /tensors/yolo-v8-segmentation-out-detections-normalized.md
+[protos]: /tensors/yolo-v8-segmentation-out-protos.md

--- a/tensor-id-register.md
+++ b/tensor-id-register.md
@@ -10,11 +10,15 @@
 |classification-generic-softmaxed-out | [details](/tensors/classification-generic-softmaxed-out.md) |
 |ultra-lightweight-face-detection-rfb-320-v1-variant-1-out-scores | [details](/tensors/ultra-lightweight-face-detection-rfb-320-v1-variant-1-out-scores.md) |
 |ultra-lightweight-face-detection-rfb-320-v1-variant-1-out-boxes-without-postproc | [details](/tensors/ultra-lightweight-face-detection-rfb-320-v1-variant-1-out-boxes-without-postproc.md) |
+|yolo-v8-out | [details](/tensors/yolo-v8-out.md) |
+|yolo-v8-obb-out | [details](/tensors/yolo-v8-obb-out.md) |
 |yolo-v8-pose-out | [details](/tensors/yolo-v8-pose-out.md) |
 |yolo-v8-segmentation-out-detections | [details](/tensors/yolo-v8-segmentation-out-detections.md) |
 |yolo-v8-segmentation-out-protos | [details](/tensors/yolo-v8-segmentation-out-protos.md) |
-|yolo-v8-out | [details](/tensors/yolo-v8-out.md) |
-|yolo-v8-obb-out | [details](/tensors/yolo-v8-obb-out.md) |
+|yolo-v8-out-normalized | [details](/tensors/yolo-v8-out-normalized.md) |
+|yolo-v8-obb-out-normalized | [details](/tensors/yolo-v8-obb-out-normalized.md) |
+|yolo-v8-pose-out-normalized | [details](/tensors/yolo-v8-pose-out-normalized.md) |
+|yolo-v8-segmentation-out-detections-normalized | [details](/tensors/yolo-v8-segmentation-out-detections-normalized.md) |
 |yolox-out | [details](/tensors/yolox-out.md) |
 
 # Tensor Groups (Model Family)
@@ -25,3 +29,4 @@
 |ultra-lightweight-face-detection-rfb-320-v1-variant-1-out | [details](/tensor-groups/ultra-lightweight-face-detection-rfb-320-v1-variant-1-out.md) |
 |ultra-lightweight-face-detection-rfb-320-v1-without-postproc-out | [details](/tensor-groups/ultra-lightweight-face-detection-rfb-320-v1-without-postproc-out.md) |
 |yolo-v8-segmentation-out | [details](/tensor-groups/yolo-v8-segmentation-out.md) |
+|yolo-v8-segmentation-out-normalized | [details](/tensor-groups/yolo-v8-segmentation-out-normalized.md) |

--- a/tensors/yolo-v8-obb-out-normalized.md
+++ b/tensors/yolo-v8-obb-out-normalized.md
@@ -1,0 +1,85 @@
+# Classification
+
+- tensor-group: no
+- layer-type: output
+- use-case: oriented-object-detection
+
+# Description
+
+Combined oriented bounding box detection predictions containing bounding boxes, class
+probabilities, and rotation angle for YOLOv8 OBB models exported with older Ultralytics
+versions that do not embed stride multiplication in the ONNX detect head.
+
+This tensor has the same structure as [yolo-v8-obb-out](/tensors/yolo-v8-obb-out.md) except that
+bounding box coordinates (X, Y, W, H) are **normalized to [0, 1]** relative to the input image
+dimensions, rather than expressed in pixel space. The rotation angle R is unchanged. Models
+exported with Ultralytics prior to the stride-folding change produce this encoding.
+
+## Detection Predictions Tensor
+
+- tensor-shape: BATCH_SIZE x (4 + NUM_CLASSES + 1) x NUM_CANDIDATES
+- tensor-datatype: float32
+- tensor-id: yolo-v8-obb-out-normalized
+- memory-layout: column-major order
+
+Where:
+ * BATCH_SIZE is the size of the batch
+ * NUM_CLASSES is the number of classes the model was trained on
+ * NUM_CANDIDATES is the total number of candidates
+
+### Known Aliases
+* output0
+
+### Encoding
+
+Scheme: (X: x-coord, Y: y-coord, W: width, H: height, C0-Cc: class probabilities, R: rotation)
+
+Bounding box fields X, Y, W, H are **center-format** and **normalized** to the input image
+resolution (values in [0, 1]). To obtain pixel coordinates multiply by the input image
+width/height. The rotation angle R is in radians and is not normalized.
+
+Memory layout of tensor data:
+
+| Index                                   | Symbol | Value               | Comment                                |
+|-----------------------------------------|--------|---------------------|----------------------------------------|
+| 0                                       | X      | box-0-x-center      | tensor-start, x-center-plane-start     |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × 1 - 1                  | X      | box-C-x-center      | tensor-continue, x-center-plane-end    |
+| NUM_CANDIDATES × 1                      | Y      | box-0-y-center      | tensor-continue, y-center-plane-start  |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × 2 - 1                  | Y      | box-C-y-center      | tensor-continue, y-center-plane-end    |
+| NUM_CANDIDATES × 2                      | W      | box-0-width         | tensor-continue, width-plane-start     |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × 3 - 1                  | W      | box-C-width         | tensor-continue, width-plane-end       |
+| NUM_CANDIDATES × 3                      | H      | box-0-height        | tensor-continue, height-plane-start    |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × 4 - 1                  | H      | box-C-height        | tensor-continue, height-plane-end      |
+| NUM_CANDIDATES × 4                      | C0     | box-0-class-0-prob  | tensor-continue, class-0-plane-start   |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × 5 - 1                  | C0     | box-C-class-0-prob  | tensor-continue, class-0-plane-end     |
+| NUM_CANDIDATES × 5                      | C1     | box-0-class-1-prob  | tensor-continue, class-1-plane-start   |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × 6 - 1                  | C1     | box-C-class-1-prob  | tensor-continue, class-1-plane-end     |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × (NUM_CLASSES + 3)      | Cc     | box-0-class-c-prob  | tensor-continue, class-c-plane-start   |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × (NUM_CLASSES + 4) - 1  | Cc     | box-C-class-c-prob  | tensor-continue, class-c-plane-end     |
+| NUM_CANDIDATES × (NUM_CLASSES + 4)      | R      | box-0-rotation      | tensor-continue, rotation-plane-start  |
+| ...                                     | ...    | ...                 | ...                                    |
+| NUM_CANDIDATES × (NUM_CLASSES + 5) - 1  | R      | box-C-rotation      | tensor-end, rotation-plane-end         |
+
+# External References
+
+* [YOLOv8 Paper](https://arxiv.org/abs/2305.09972)
+* [Ultralytics YOLOv8 Documentation](https://docs.ultralytics.com/models/yolov8/)
+* [Ultralytics ONNX export source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py)
+
+# Models
+
+* [YOLOv8n-obb (old Ultralytics export)](https://github.com/ultralytics/assets/releases)
+
+# Tensor Decoders
+
+|Framework  | Links |
+|---        |---    |
+|GStreamer  | [yolov8tensordec](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/tensordecoders) |

--- a/tensors/yolo-v8-obb-out.md
+++ b/tensors/yolo-v8-obb-out.md
@@ -30,6 +30,8 @@ Where:
 
 Scheme: (X: x-coord, Y: y-coord, W: width, H: height, C0-Cc: class probabilities, R: rotation)
 
+Bounding box fields X, Y, W, H are **center-format** and expressed in **pixel space** relative to the input image dimensions. The rotation angle R is in radians.
+
 The tensor contains (4 + NUM_CLASSES + 1) channels with the following layout per spatial location:
 
 | Channels 0-3 | Channels 4-(NUM_CLASSES+3) | Channel NUM_CLASSES+4 |

--- a/tensors/yolo-v8-out-normalized.md
+++ b/tensors/yolo-v8-out-normalized.md
@@ -1,0 +1,71 @@
+# Classification
+
+- tensor-group: no
+- layer-type: output
+- use-case: object-detection
+
+# Description
+
+Combined detection predictions containing bounding boxes and class probabilities for YOLO v8-v11 object detection models exported with older Ultralytics versions that do not embed stride multiplication in the ONNX detect head.
+
+This tensor has the same structure as [yolo-v8-out](/tensors/yolo-v8-out.md) except that bounding box coordinates (X, Y, W, H) are **normalized to [0, 1]** relative to the input image dimensions, rather than expressed in pixel space. Models exported with Ultralytics prior to the stride-folding change produce this encoding.
+
+## Detection Predictions Tensor
+
+- tensor-shape: BATCH_SIZE x (4 + NUM_CLASSES) x NUM_CANDIDATES
+- tensor-datatype: float32
+- tensor-id: yolo-v8-out-normalized
+- memory-layout: column-major order
+
+Where:
+ * BATCH_SIZE is the size of the batch
+ * NUM_CLASSES is the number of classes the model was trained on
+ * NUM_CANDIDATES is the total number of candidates
+
+### Known Aliases
+* output0
+
+### Encoding
+
+Scheme: (X: x-coord, Y: y-coord, W: width, H: height, C0-Cx: class probabilities)
+
+Bounding box fields X, Y, W, H are **center-format** and **normalized** to the input image resolution (values in [0, 1]). To obtain pixel coordinates multiply by the input image width/height.
+
+Memory layout of tensor data:
+
+|Index                                    | Symbol | Value                  | Comment                               |
+|---                                      |---     |---                     |---                                    |
+|0                                        | X      | box-0-x-center         | tensor-start, x-center-plane-start    |
+|...                                      | ...    | ...                    | ...                                   |
+|NUM_CANDIDATES × 1 - 1                   | X      | box-C-x-center         | x-center-plane-end                    |
+|NUM_CANDIDATES × 1                       | Y      | box-0-y-center         | y-center-plane-start                  |
+|...                                      | ...    | ...                    | ...                                   |
+|NUM_CANDIDATES × 2 - 1                   | Y      | box-C-y-center         | y-center-plane-end                    |
+|NUM_CANDIDATES × 2                       | W      | box-0-width            | width-plane-start                     |
+|...                                      | ...    | ...                    | ...                                   |
+|NUM_CANDIDATES × 3 - 1                   | W      | box-C-width            | width-plane-end                       |
+|NUM_CANDIDATES × 3                       | H      | box-0-height           | height-plane-start                    |
+|...                                      | ...    | ...                    | ...                                   |
+|NUM_CANDIDATES × 4 - 1                   | H      | box-C-height           | height-plane-end                      |
+|NUM_CANDIDATES × 4                       | C0     | box-0-class-0-prob     | class-0-plane-start                   |
+|...                                      | ...    | ...                    | ...                                   |
+|NUM_CANDIDATES × 5 - 1                   | C0     | box-C-class-0-prob     | class-0-plane-end                     |
+|NUM_CANDIDATES × 5                       | C1     | box-0-class-1-prob     | class-1-plane-start                   |
+|...                                      | ...    | ...                    | ...                                   |
+|NUM_CANDIDATES × (NUM_CLASSES + 4) - 1  | Cx     | box-C-class-c-prob     | tensor-end, last-class-plane-end      |
+
+# External References
+
+* [YOLOv8 Paper](https://arxiv.org/abs/2305.09972)
+* [Ultralytics YOLOv8 Documentation](https://docs.ultralytics.com/models/yolov8/)
+* [Ultralytics ONNX export source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py)
+
+# Models
+
+* [YOLOv8n (old Ultralytics export)](https://github.com/ultralytics/assets/releases)
+
+# Tensor Decoders
+
+|Framework  | Links |
+|---        |---    |
+|GStreamer  | [yolov8tensordec](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/tensordecoders) |

--- a/tensors/yolo-v8-out.md
+++ b/tensors/yolo-v8-out.md
@@ -29,6 +29,8 @@ Where:
 
 Scheme: (X: x-coord, Y: y-coord, W: width, H: height, C0-Cx: class probabilities)
 
+Bounding box fields X, Y, W, H are **center-format** and expressed in **pixel space** relative to the input image dimensions.
+
 The tensor contains 116 channels with the following layout per spatial location:
 
 |Channels 0-3  | Channels 4-x |

--- a/tensors/yolo-v8-pose-out-normalized.md
+++ b/tensors/yolo-v8-pose-out-normalized.md
@@ -1,0 +1,98 @@
+# Classification
+
+- tensor-group: no
+- layer-type: output
+- use-case: pose-estimation
+
+# Description
+
+Combined pose estimation predictions containing bounding boxes, person confidence scores,
+and keypoint coordinates for YOLOv8 pose models exported with older Ultralytics versions
+that do not embed stride multiplication in the ONNX detect head.
+
+This tensor has the same structure as [yolo-v8-pose-out](/tensors/yolo-v8-pose-out.md) except that
+bounding box coordinates (X, Y, W, H) and keypoint coordinates (KX, KY) are **normalized to [0, 1]**
+relative to the input image dimensions, rather than expressed in pixel space. Models exported with
+Ultralytics prior to the stride-folding change produce this encoding.
+
+## Pose Predictions Tensor
+
+- tensor-shape: BATCH_SIZE x 56 x NUM_CANDIDATES
+- tensor-datatype: float32
+- tensor-id: yolo-v8-pose-out-normalized
+- memory-layout: column-major order
+
+Where:
+ * BATCH_SIZE is the size of the batch
+ * 56 = 4 (bbox) + 1 (score) + 17×3 (keypoints: x, y, confidence)
+ * NUM_CANDIDATES is the total number of candidates
+
+### Known Aliases
+* output0
+
+### Encoding
+
+Scheme: [X, Y, W, H, S, K1X, K1Y, K1C, ..., K17X, K17Y, K17C]
+
+- X, Y = box center (normalized to [0, 1])
+- W, H = box width/height (normalized to [0, 1])
+- S = person-confidence score
+- KkX, KkY = keypoint k coordinates (normalized to [0, 1]), k = 1...17
+- KkC = keypoint k confidence score, k = 1...17
+
+To obtain pixel coordinates multiply X, Y, W, H, KkX, KkY by the input image width/height.
+
+Memory layout of tensor data:
+
+| Index                               | Symbol | Value                           | Comment                                         |
+|-------------------------------------|--------|---------------------------------|-------------------------------------------------|
+| 0                                   | X      | box-0-x-center                  | tensor-start, x-center-plane-start              |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 1 - 1             | X      | box-C-x-center                  | tensor-continue, x-center-plane-end             |
+| NUM_CANDIDATES × 1                  | Y      | box-0-y-center                  | tensor-continue, y-center-plane-start           |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 2 - 1             | Y      | box-C-y-center                  | tensor-continue, y-center-plane-end             |
+| NUM_CANDIDATES × 2                  | W      | box-0-width                     | tensor-continue, width-plane-start              |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 3 - 1             | W      | box-C-width                     | tensor-continue, width-plane-end                |
+| NUM_CANDIDATES × 3                  | H      | box-0-height                    | tensor-continue, height-plane-start             |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 4 - 1             | H      | box-C-height                    | tensor-continue, height-plane-end               |
+| NUM_CANDIDATES × 4                  | S      | box-0-confidence-score          | tensor-continue, confidence-score-plane-start   |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 5 - 1             | S      | box-C-confidence-score          | tensor-continue, confidence-score-plane-end     |
+| NUM_CANDIDATES × 5                  | K1X    | box-0-keypoint-1-x-coord        | tensor-continue, keypoint-1-x-plane-start       |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 6 - 1             | K1X    | box-C-keypoint-1-x-coord        | tensor-continue, keypoint-1-x-plane-end         |
+| NUM_CANDIDATES × 6                  | K1Y    | box-0-keypoint-1-y-coord        | tensor-continue, keypoint-1-y-plane-start       |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 7 - 1             | K1Y    | box-C-keypoint-1-y-coord        | tensor-continue, keypoint-1-y-plane-end         |
+| NUM_CANDIDATES × 7                  | K1C    | box-0-keypoint-1-confidence     | tensor-continue, keypoint-1-confidence-plane-start |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 8 - 1             | K1C    | box-C-keypoint-1-confidence     | tensor-continue, keypoint-1-confidence-plane-end   |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 53                 | K17X   | box-0-keypoint-17-x-coord       | tensor-continue, keypoint-17-x-plane-start      |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 54 - 1            | K17X   | box-C-keypoint-17-x-coord       | tensor-continue, keypoint-17-x-plane-end        |
+| NUM_CANDIDATES × 54                 | K17Y   | box-0-keypoint-17-y-coord       | tensor-continue, keypoint-17-y-plane-start      |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 55 - 1            | K17Y   | box-C-keypoint-17-y-coord       | tensor-continue, keypoint-17-y-plane-end        |
+| NUM_CANDIDATES × 55                 | K17C   | box-0-keypoint-17-confidence    | tensor-continue, keypoint-17-confidence-plane-start |
+| ...                                 | ...    | ...                             | ...                                             |
+| NUM_CANDIDATES × 56 - 1            | K17C   | box-C-keypoint-17-confidence    | tensor-end, keypoint-17-confidence-plane-end    |
+
+# External References
+
+* [YOLOv8 Paper](https://arxiv.org/abs/2305.09972)
+* [Ultralytics YOLOv8 Documentation](https://docs.ultralytics.com/models/yolov8/)
+* [Ultralytics ONNX export source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py)
+
+# Models
+
+* [YOLOv8s-pose (old Ultralytics export)](https://github.com/ultralytics/assets/releases)
+
+# Tensor Decoders
+
+|Framework  | Links |
+|---        |---    |
+|GStreamer  | [yolov8tensordec](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/tensordecoders) |

--- a/tensors/yolo-v8-pose-out.md
+++ b/tensors/yolo-v8-pose-out.md
@@ -46,14 +46,13 @@ Foreach i in outputs.shape[0]:
 
 ### Encoding
 
-Center-based format, normalized to [0,1]:
-
 Scheme: [X, Y, W, H, S, K1X, K1Y, K1C, ..., K17X, K17Y, K17C]
 
-- X, Y = box center
-- W, H = box width/height
+- X, Y = box center, expressed in **pixel space** relative to the input image dimensions
+- W, H = box width/height, expressed in **pixel space** relative to the input image dimensions
 - S = person-confidence
-- KkX, KkY, KkC = keypoint k (x, y, confidence), k = 1...17
+- KkX, KkY = keypoint k coordinates, expressed in **pixel space**, k = 1...17
+- KkC = keypoint k confidence score, k = 1...17
 
 Memory layout of output tensor data (shape `1×56×8400`):
 

--- a/tensors/yolo-v8-segmentation-out-detections-normalized.md
+++ b/tensors/yolo-v8-segmentation-out-detections-normalized.md
@@ -1,0 +1,98 @@
+# Classification
+
+- tensor-group: no
+- layer-type: output
+- use-case: instance-segmentation
+- part-of-tensor-groups:
+    - [yolo-v8-segmentation-out-normalized](/tensor-groups/yolo-v8-segmentation-out-normalized.md)
+
+# Description
+
+Combined detection predictions containing bounding boxes, class probabilities, and
+mask coefficients for YOLOv8 segmentation models exported with older Ultralytics versions
+that do not embed stride multiplication in the ONNX detect head.
+
+This tensor has the same structure as [yolo-v8-segmentation-out-detections](/tensors/yolo-v8-segmentation-out-detections.md)
+except that bounding box coordinates (X, Y, W, H) are **normalized to [0, 1]** relative to the
+input image dimensions, rather than expressed in pixel space. Models exported with Ultralytics
+prior to the stride-folding change produce this encoding.
+
+## Detection Predictions Tensor
+
+- tensor-shape: BATCH_SIZE x (4 + NUM_CLASSES + NUM_MASKS) x NUM_CANDIDATES
+- tensor-datatype: float32
+- tensor-id: yolo-v8-segmentation-out-detections-normalized
+- memory-layout: column-major order
+
+Where:
+ * BATCH_SIZE is the size of the batch
+ * NUM_CLASSES is the number of classes the model was trained on
+ * NUM_MASKS is the number of mask coefficients per detection
+ * NUM_CANDIDATES is the total number of candidates, derived from the input image dimensions.
+   YOLOv8 generates candidates from three feature map levels (strides 8, 16, 32):
+   `NUM_CANDIDATES = (H/8 × W/8) + (H/16 × W/16) + (H/32 × W/32)`
+   e.g. for a 640×640 input: `(80×80) + (40×40) + (20×20) = 8400`
+
+### Known Aliases
+* output0
+
+### Encoding
+
+Scheme: (X: x-coord, Y: y-coord, W: width, H: height, C0-Cc: class probabilities, M0-Mm: mask coefficients)
+
+Bounding box fields X, Y, W, H are **center-format** and **normalized** to the input image
+resolution (values in [0, 1]). To obtain pixel coordinates multiply by the input image
+width/height.
+
+Memory layout of tensor data:
+
+|Index                                                    | Symbol | Value                  | Comment                                    |
+|---                                                      |---     |---                     |---                                         |
+|0                                                        | X      | box-0-x-center         | tensor-start, x-center-plane-start         |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × 1 - 1                                   | X      | box-C-x-center         | tensor-continue, x-center-plane-end        |
+|NUM_CANDIDATES × 1                                       | Y      | box-0-y-center         | tensor-continue, y-center-plane-start      |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × 2 - 1                                   | Y      | box-C-y-center         | tensor-continue, y-center-plane-end        |
+|NUM_CANDIDATES × 2                                       | W      | box-0-width            | tensor-continue, width-plane-start         |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × 3 - 1                                   | W      | box-C-width            | tensor-continue, width-plane-end           |
+|NUM_CANDIDATES × 3                                       | H      | box-0-height           | tensor-continue, height-plane-start        |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × 4 - 1                                   | H      | box-C-height           | tensor-continue, height-plane-end          |
+|NUM_CANDIDATES × 4                                       | C0     | box-0-class-0-prob     | tensor-continue, class-0-plane-start       |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × 5 - 1                                   | C0     | box-C-class-0-prob     | tensor-continue, class-0-plane-end         |
+|NUM_CANDIDATES × 5                                       | C1     | box-0-class-1-prob     | tensor-continue, class-1-plane-start       |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × 6 - 1                                   | C1     | box-C-class-1-prob     | tensor-continue, class-1-plane-end         |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × (NUM_CLASSES + 3)                       | Cc     | box-0-class-c-prob     | tensor-continue, class-c-plane-start       |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × (NUM_CLASSES + 4) - 1                   | Cc     | box-C-class-c-prob     | tensor-continue, class-c-plane-end         |
+|NUM_CANDIDATES × (NUM_CLASSES + 4)                       | M0     | box-0-mask-coeff-0     | tensor-continue, mask-coeff-0-plane-start  |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × (NUM_CLASSES + 5) - 1                   | M0     | box-C-mask-coeff-0     | tensor-continue, mask-coeff-0-plane-end    |
+|NUM_CANDIDATES × (NUM_CLASSES + 5)                       | M1     | box-0-mask-coeff-1     | tensor-continue, mask-coeff-1-plane-start  |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × (NUM_CLASSES + 6) - 1                   | M1     | box-C-mask-coeff-1     | tensor-continue, mask-coeff-1-plane-end    |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × (NUM_CLASSES + NUM_MASKS + 3)           | Mm     | box-0-mask-coeff-m     | tensor-continue, mask-coeff-m-plane-start  |
+|...                                                      | ...    | ...                    | ...                                        |
+|NUM_CANDIDATES × (NUM_CLASSES + NUM_MASKS + 4) - 1       | Mm     | box-C-mask-coeff-m     | tensor-end, mask-coeff-m-plane-end         |
+
+# External References
+
+* [YOLOv8 Paper](https://arxiv.org/abs/2305.09972)
+* [Ultralytics YOLOv8 Documentation](https://docs.ultralytics.com/models/yolov8/)
+* [Ultralytics ONNX export source](https://github.com/ultralytics/ultralytics/blob/main/ultralytics/engine/exporter.py)
+
+# Models
+
+* [YOLOv8s-seg (old Ultralytics export)](https://github.com/ultralytics/assets/releases)
+
+# Tensor Decoders
+
+|Framework  | Links |
+|---        |---    |
+|GStreamer  | [yolov8tensordec](https://gitlab.freedesktop.org/gstreamer/gstreamer/-/tree/main/subprojects/gst-plugins-bad/gst/tensordecoders) |

--- a/tensors/yolo-v8-segmentation-out-detections.md
+++ b/tensors/yolo-v8-segmentation-out-detections.md
@@ -38,6 +38,8 @@ Where:
 
 Scheme: (X: x-coord, Y: y-coord, W: width, H: height, C0-Cc: class probabilities, M0-Mm: mask coefficients)
 
+Bounding box fields X, Y, W, H are **center-format** and expressed in **pixel space** relative to the input image dimensions.
+
 The tensor contains (4 + NUM_CLASSES + NUM_MASKS) channels with the following layout per spatial location:
 
 |Channels 0-3  | Channels 4-(NUM_CLASSES+3)     | Channels (NUM_CLASSES+4)-(NUM_CLASSES+NUM_MASKS+3) |


### PR DESCRIPTION
There are some variants of the YOLO export that outputs tensors with coordinates in the [0,1] space instead of being in pixels.

Let's describe those separately.